### PR TITLE
Joomla's modern routing option brakes buttons

### DIFF
--- a/assets/js/gcomments.js
+++ b/assets/js/gcomments.js
@@ -84,7 +84,7 @@ function deleteComment(id) {
             comment_id: id
         },
         type: 'POST',
-        url: 'index.php?option=com_ajax&format=json&module=gcomments&method=removeComment',
+        url: '../index.php?option=com_ajax&format=json&module=gcomments&method=removeComment',
         dataType: 'json',
         success: function(data) {
             if (data.success === true) {
@@ -117,7 +117,7 @@ function getData(lstart) {
             gstart: lstart
         },
         type: 'GET',
-        url: 'index.php?option=com_ajax&format=json&module=gcomments&method=getComments',
+        url: '../index.php?option=com_ajax&format=json&module=gcomments&method=getComments',
         dataType: 'json',
         success: function(data) {
             if (data.success === true) {


### PR DESCRIPTION
Activating Joomlas's modern routing option for urls without ids breacks the delete and load more button funtion. Addings '../' to the urls solves this problem.